### PR TITLE
use Keyword.pop/3 instead of Keyword.pop!/2

### DIFF
--- a/lib/harness/manifest.ex
+++ b/lib/harness/manifest.ex
@@ -28,7 +28,7 @@ defmodule Harness.Manifest do
   def read(path) do
     with false <- File.dir?(path),
          {config, _files} <- Config.Reader.read_imports!(path),
-         {manifest_kwlist, other_config} <- Keyword.pop!(config, :harness),
+         {manifest_kwlist, other_config} <- Keyword.pop(config, :harness),
          %__MODULE__{} = manifest <- struct(__MODULE__, manifest_kwlist),
          :ok <- manifest_version_match!(manifest),
          :ok <- harness_version_match!(manifest) do


### PR DESCRIPTION
slack context: https://cuatrohq.slack.com/archives/C01AY5REC9X/p1615224043053800

Keyword.pop!/2 was added to the std lib in 1.10.0 according to the docs

harness fails to compile on elixir 1.9 until this gets switched to Keyword.pop/3