### PR TITLE
add harness.loadpaths to check harness packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 - 2021-11-24
+## 0.7.0 - 2021-11-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 - 2021-11-24
+
+### Added
+
+- Added a `mix harness.loadpaths` Mix Task that mirrors `mix deps.loadpaths`
+    - this task loads, compiles, and checks harness packages to ensure that
+      they are up to date and can be installed
+
 ## 0.6.2 - 2021-03-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 - Added a `mix harness.loadpaths` Mix Task that mirrors `mix deps.loadpaths`
     - this task loads, compiles, and checks harness packages to ensure that
       they are up to date and can be installed
+- Added `--no-compile` and `--no-deps-check` flags to `mix harness` task
 
 ## 0.6.2 - 2021-03-17
 

--- a/lib/mix/tasks/harness.ex
+++ b/lib/mix/tasks/harness.ex
@@ -5,20 +5,21 @@ defmodule Mix.Tasks.Harness do
 
   Configuration of which files to generate and link is according to the current
   directory's harness manifest (`harness.exs`).
+
+  ## Command line options
+
+    * `--no-compile` - skips the compilation of harness packages
+    * `--no-deps-check` - skips a check for out of date dependencies
   """
 
   use Mix.Task
 
-  alias Harness.{Manifest, Renderer}
-
   @impl Mix.Task
-  def run(_args) do
+  def run(args) do
     path = "."
 
-    Mix.Task.run("harness.compile", [path])
+    Mix.Task.run("harness.loadpaths", args)
 
-    Manifest.load(path)
-
-    Renderer.render(path)
+    Harness.Renderer.render(path)
   end
 end

--- a/lib/mix/tasks/harness.loadpaths.ex
+++ b/lib/mix/tasks/harness.loadpaths.ex
@@ -1,0 +1,94 @@
+defmodule Mix.Tasks.Harness.Loadpaths do
+  @shortdoc "Checks, compiles, and loads all harness packages"
+  @moduledoc """
+  Checks, compiles, and loads all harness packages
+
+  ## Command line options
+
+    * `--no-compile` - skips the compilation of harness packages
+    * `--no-deps-check` - skips a check for out of date dependencies
+  """
+
+  # the upstream of this code is here: https://github.com/elixir-lang/elixir/blob/58518794306c70204de14f9ed214fb7f296769d9/lib/mix/lib/mix/tasks/deps.loadpaths.ex
+  # this code should be considered copyright the Elixir Core Team
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(args) do
+    path = "."
+
+    Harness.Manifest.load(path)
+
+    unless "--no-deps-check" in args do
+      Mix.Dep.load_and_cache()
+      |> deps_check("--no-compile" in args)
+    end
+  end
+
+  defp deps_check(deps, no_compile?) do
+    deps = Enum.map(deps, &Mix.Dep.check_lock/1)
+    {not_ok, compile} = partition(deps, [], [])
+
+    cond do
+      not_ok != [] ->
+        show_not_ok!(not_ok)
+
+      compile == [] or no_compile? ->
+        :ok
+
+      true ->
+        Mix.Tasks.Deps.Compile.compile(compile)
+        |> Enum.map(& &1.app)
+        |> Mix.Dep.filter_by_name(Mix.Dep.load_and_cache())
+        |> Enum.filter(&(not Mix.Dep.ok?(&1)))
+        |> show_not_ok!
+    end
+  end
+
+  defp partition([dep | deps], not_ok, compile) do
+    cond do
+      Mix.Dep.compilable?(dep) or
+          (Mix.Dep.ok?(dep) and dep.scm.fetchable? == false) ->
+        if dep.opts[:from_umbrella] do
+          partition(deps, not_ok, compile)
+        else
+          partition(deps, not_ok, [dep | compile])
+        end
+
+      Mix.Dep.ok?(dep) ->
+        partition(deps, not_ok, compile)
+
+      true ->
+        partition(deps, [dep | not_ok], compile)
+    end
+  end
+
+  defp partition([], not_ok, compile) do
+    {Enum.reverse(not_ok), Enum.reverse(compile)}
+  end
+
+  defp show_not_ok!([]) do
+    :ok
+  end
+
+  defp show_not_ok!(deps) do
+    shell = Mix.shell()
+    shell.error("Unchecked dependencies for environment #{Mix.env()}:")
+
+    Enum.each(deps, fn dep ->
+      shell.error("* #{Mix.Dep.format_dep(dep)}")
+      shell.error("  #{format_status(dep)}")
+    end)
+
+    Mix.raise("Can't continue due to errors on dependencies")
+  end
+
+  defp format_status(mix_dep) do
+    mix_dep
+    |> Mix.Dep.format_status()
+    |> String.replace(~r/mix deps.get/, "mix harness.get")
+    |> String.replace(~r/mix deps.compile/, "mix harness.compile")
+    |> String.replace(~r/mix.lock/, "harness.lock")
+  end
+end


### PR DESCRIPTION
closes #18 

this is a harness version of `mix deps.loadpaths`, which loads/compiles/checks mix dependencies to make sure your lockfile is not out of date with what you have pulled down locally

it'll give you a nice helpful error if you switch to a new branch or pull or whatever in a harness project where the harness packages have changed. e.g.

```
root@galacticon:/code/agora# mix harness
Unchecked dependencies for environment dev:
* harness_read_model (Hex package)
  lock mismatch: the dependency is out of date. To fetch locked version run "mix harness.get"
** (Mix) Can't continue due to errors on dependencies
```