### PR TITLE
Add harness to vm path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.4 - 2023-08-09
+
+### Fixed
+
+- This version fixes warnings and errors encountered when using `harness` with
+  Elixir 1.15
+    - added harness archive ebin path to VM path list because Elixir 1.15
+      prunes code paths before compiling
+    - `EEx.eval_string/3` is now used instead of `EEx.eval_file/3` when
+      rendering templates with import of `Harness.Renderer.Helpers` functions
+      being appended to every template binary because passing `:functions` in
+      options is deprecated since Elixir 1.13
+
 ## 0.7.3 - 2023-04-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 - 2023-04-05
+
+### Changed
+
+- Updated `hackney` from 1.16 to 1.18.1
+- Pinned ubuntu runner to `ubuntu-20.04` in workflows because of OTP 22.3
+
 ## 0.7.2 - 2021-11-29
 
 ### Fixed

--- a/lib/harness/renderer/file.ex
+++ b/lib/harness/renderer/file.ex
@@ -1,7 +1,7 @@
 defmodule Harness.Renderer.File do
   @moduledoc false
 
-  alias Harness.Renderer.{Run, Helpers, Utils}
+  alias Harness.Renderer.{Run, Utils}
 
   # a common interface for being a file
 
@@ -65,13 +65,9 @@ defmodule Harness.Renderer.File do
 
     generated_contents =
       file.source_path
-      |> EEx.eval_file(
-        [assigns: run.generator_config],
-        functions: [
-          {Helpers, Helpers.__info__(:functions)},
-          {Elixir.Kernel, Kernel.__info__(:functions)}
-        ]
-      )
+      |> File.read!()
+      |> (&("<% import Harness.Renderer.Helpers %>" <> &1)).()
+      |> EEx.eval_string(assigns: run.generator_config)
       # this shouldn't be necessary but it prevents a strange dialyzer warn
       |> format_elixir(path, Path.extname(file.source_path))
 

--- a/lib/mix/tasks/harness.ex
+++ b/lib/mix/tasks/harness.ex
@@ -26,6 +26,8 @@ defmodule Mix.Tasks.Harness do
       Mix.Task.run("harness.compile", [path])
     end
 
+    Harness.Manifest.load(path)
+
     Harness.Renderer.render(path)
   end
 end


### PR DESCRIPTION
these changes are needed for moving our harness libraries (aggregate, micro_controller, pixel, process_manager and read_model) to Elixir 1.15 (with OTP 26)

since Elixir 1.15 prunes code paths before compilation to increase compilation speed, when using `mix harness` task in one of our harnessed apps, we need to have harness modules available for the task(s) to complete successfully

also, since passing `functions: [...]` to `EEx.eval_file` (through `Code.eval_string`) is deprecated since Elixir 1.13, I first read the template to binary, prepend the import of the functions from Harness.Renderer.Helpers module, and then use `EEx.eval_string`