### PR TITLE
Make sure tasks are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,32 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.5 - 2024-09-25
+## 0.8.3 - 2024-09-25
 
 ### Fixed
 
 - Makes sure all harness archive tasks are loaded and available to use
 
-## 0.7.4 - 2023-08-09
+## 0.8.2 - 2024-03-18
+
+### Changed
+
+- Updated `actions/checkout@` from `v3` to `v4` in GH actions
+- Updated `actions/cache@` from `v3` to `v4` in GH actions
+- Updated `NFIBrokerage/create-release@` from `v3` to `v4` in GH actions
+
+## 0.8.1 - 2023-08-24
+
+### Changed
+
+- Updated `actions/checkout@` from `v1` to `v3` in GH actions
+- Updated `actions/cache@` from `v1` to `v3` in GH actions
+- Updated `NFIBrokerage/create-release@` from `v2` to `v3` in GH actions
+- Change `release_name` to `name` field in `NFIBrokerage/create-release@v3`
+  action in GH actions
+- Fixed credo warnings
+
+## 0.8.0 - 2023-08-09
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.5 - 2024-09-25
+
+### Fixed
+
+- Makes sure all harness archive tasks are loaded and available to use
+
 ## 0.7.4 - 2023-08-09
 
 ### Fixed

--- a/lib/harness/manifest.ex
+++ b/lib/harness/manifest.ex
@@ -78,12 +78,15 @@ defmodule Harness.Manifest do
     :ok = ProjectStack.push(__MODULE__, config, Path.expand(path))
 
     deps = Mix.Dep.cached()
+    archive_path = archive_path()
 
     :ok =
       deps
       |> Enum.flat_map(&Mix.Dep.load_paths/1)
-      |> (&[archive_path() | &1]).()
       |> Enum.each(&Code.append_path/1)
+
+    Code.append_path(archive_path)
+    Mix.Task.load_tasks([archive_path])
 
     deps
     |> Enum.map(fn %Mix.Dep{app: app} -> app end)


### PR DESCRIPTION
running `mix harness` when `asdf_elixir_version` for a harness_process_manager has been set to `1.15.8-otp-25` results in the following error:
```
❯ mix harness
==> nimble_options
Compiling 3 files (.ex)
Generated nimble_options app
==> harness_process_manager
Compiling 1 file (.ex)
Generated harness_process_manager app
==> harness
Compiling 2 files (.ex)
error: module Projection is not loaded and could not be found. This may be happening because the module you are trying to load directly or indirectly depends on the current module
  lib/evolver.ex:4: Evolver (module)


== Compilation error in file lib/evolver.ex ==
** (CompileError) lib/evolver.ex: cannot compile module Evolver (errors have been logged)
    (elixir 1.15.8) expanding macro: Kernel.use/2
    lib/evolver.ex:4: Evolver (module)
```
further tinkering revealed that not all harness tasks are available when running `"harness.compile"` inside `Mix.Tasks.Harness.run/1`
in mix codebase the private `fetch/1` function doesn't find the appropriate task modules for `Harness.Compile` and `Harness.Check`, maybe some others also:
https://github.com/elixir-lang/elixir/blob/4e6d67c169d75476677a768f5cff553a3c8f288b/lib/mix/lib/mix/task.ex#L316

but if we load tasks from the archive install location, then all task modules are available, and `mix harness` runs without issues

---

the proposed solution might not be the only one, but seems the simplest to me, and I'm open for any suggestions